### PR TITLE
Completed Phase Three

### DIFF
--- a/TheHeist/Program.cs
+++ b/TheHeist/Program.cs
@@ -56,3 +56,22 @@ Console.WriteLine($@"
      {team.Members.Count} member(s)
 --------------------");
 team.Members.ForEach(member => member.Print());
+
+int difficultyLevel = 100;
+int teamSkillLevel = 0;
+
+team.Members.ForEach(member =>
+    {
+        teamSkillLevel += member.SkillLevel;
+    }  
+);
+
+Console.WriteLine($@"Team Skill Level: {teamSkillLevel}");
+if (teamSkillLevel >= difficultyLevel)
+{
+    Console.WriteLine("Mission Success!");
+}
+else
+{
+    Console.WriteLine("Mission Failed!");
+}


### PR DESCRIPTION
1. Stop displaying each team member's information.
2. Store a value for the *bank's difficulty level*. Set this value to 100.
3. Sum the skill levels of the team. Save that number.
4. Compare the number with the bank's difficulty level. If the team's
skill level is greater than or equal to the bank's difficulty level,
Display a success message, otherwise display a failure message.